### PR TITLE
Update EQL ticker to EQLI

### DIFF
--- a/coins
+++ b/coins
@@ -48,7 +48,7 @@
     "txfee":10000
   },
   {
-    "coin":"EQL",
+    "coin":"EQLI",
     "asset":"EQL",
     "fname": "Equaliser",
     "rpcport":10306


### PR DESCRIPTION
They've updated their ticker to EQLI: https://www.coingecko.com/en/coins/equaliser