### PR TITLE
switched to new temporary electrums for verus after height #800200

### DIFF
--- a/electrums/VRSC
+++ b/electrums/VRSC
@@ -1,6 +1,6 @@
 [
   {
-    "url": "el0.vrsc.0x03.services:10000",
+    "url": "nel0.vrsc.0x03.services:17485",
     "contact": [
       {
         "email": "0x03-ctrlc@protonmail.com"
@@ -8,7 +8,7 @@
     ]
   },
   {
-    "url": "el1.vrsc.0x03.services:10000",
+    "url": "nel1.vrsc.0x03.services:17485",
     "contact": [
       {
         "email": "0x03-ctrlc@protonmail.com"
@@ -16,7 +16,7 @@
     ]
   },
   {
-    "url": "el2.vrsc.0x03.services:10000",
+    "url": "nel2.vrsc.0x03.services:17485",
     "contact": [
       {
         "email": "0x03-ctrlc@protonmail.com"


### PR DESCRIPTION
these are temporary, meaning that i will migrate back to the `el0-el2` hostnames later on (estimating ETA about 1-2 weeks or so).

port numbers have changed and will stay at the new value even after switching back to the old hostnames, however old ports (10k) are forwarded accordingly.