### PR TITLE
Add "segwit": true for BTC.

### DIFF
--- a/coins
+++ b/coins
@@ -7,6 +7,7 @@
     "pubtype": 0,
     "p2shtype": 5,
     "wiftype": 128,
+    "segwit": true,
     "mm2": 1
   },
   {


### PR DESCRIPTION
The "segwit" flag now enables withdrawals to P2SH addresses. I've tested it by myself with BTC. New coins are coming.
Corresponding issue: https://github.com/KomodoPlatform/atomicDEX-API/issues/506