### PR TITLE
enable segwit for LTC

### DIFF
--- a/coins
+++ b/coins
@@ -2946,9 +2946,10 @@
     "fname": "Litecoin",
     "rpcport": 9332,
     "pubtype": 48,
-    "p2shtype": 5,
+    "p2shtype": 50,
     "wiftype": 176,
     "txfee": 10000,
+    "segwit": true,
     "mm2": 1
   },
   {


### PR DESCRIPTION
p2shtype set to 50: https://github.com/litecoin-project/litecoin/blob/master/src/chainparams.cpp#L140
segwit for LTC works fine: https://blockchair.com/litecoin/transaction/da317a2165c6fb45cb3a7289b6c5f9e8fbcf66f6a508c7d39468e21206cd7962