### PR TITLE
set txfee for RVN 10x higher

### DIFF
--- a/coins
+++ b/coins
@@ -1948,7 +1948,7 @@
     "pubtype": 60,
     "p2shtype": 122,
     "wiftype": 128,
-    "txfee": 100000,
+    "txfee": 1000000,
     "mm2": 1
   },
   {


### PR DESCRIPTION
because of `the transaction was rejected by network rules. min relay fee not met` and `"relayfee": 0.01000000`
