### PR TITLE
update required confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 NOTE: The filename in each subdirectory needs to match the coin's symbol exactly, it is the unique field by which different coins are indexed. Please use .png files for icons
 
 ### About this repository
-This repository is the coins database which is accessed by the [Marketmaker 2.0](https://github.com/KomodoPlatform/atomicDEX-API/) and graphical applications like [AtomicDEX Mobile](https://github.com/KomodoPlatform/atomicDEX), HyperDEX etc. to enable coins for trading. 
+This repository is the coins database which is accessed by [AtomicDEX API](https://github.com/KomodoPlatform/atomicDEX-API/) and graphical applications like [AtomicDEX Mobile](https://github.com/KomodoPlatform/atomicDEX), HyperDEX etc. to enable coins for trading.
 
 When submitting a pull request to add a coin, make sure you have completed this checklist:
 
-### 0. The coin must have participated in a successful Atomic Swap using [atomicDEX/Marketmaker 2.0](https://github.com/KomodoPlatform/atomicDEX-API/)
+### 0. The coin must have participated in a successful Atomic Swap using [AtomicDEX](https://github.com/KomodoPlatform/atomicDEX-API/)
 When submitting your coin add request please post the 5 transactions URLs produced by successful swap in separate file inside [swaps dir](swaps), [example](swaps/BEER-ETOMIC.md). This means that before submitting the further steps information to this coins database repo, you would have performed an atomic swap, and the further steps explains the expected files/values to be submitted to this database repo.
 
 You can learn about performing an atomic swap from our documentation at [this link](https://developers.komodoplatform.com/basic-docs/atomicdex/atomicdex-tutorials/introduction-to-atomicdex.html)
@@ -18,64 +18,69 @@ You need the following info in JSON format added to the [coins](coins) file:
 
 ```shell
 # Example 1
-{
-  "coin": "LTC",
-  "name": "litecoin",
-  "fname": "Litecoin",
-  "rpcport": 9332,
-  "pubtype": 48,
-  "p2shtype": 5,
-  "wiftype": 176,
-  "txfee": 100000,
-  "mm2": 1
-}
+  {
+    "coin": "LTC",
+    "name": "litecoin",
+    "fname": "Litecoin",
+    "rpcport": 9332,
+    "pubtype": 48,
+    "p2shtype": 50,
+    "wiftype": 176,
+    "txfee": 10000,
+    "segwit": true,
+    "mm2": 1,
+    "required_confirmations": 2
+  }
 
 # Example 2
-{
-  "coin":"PEW",
-  "name":"brofist",
-  "fname": "Brofist",
-  "confpath": "USERHOME/.brofistcore/brofist.conf"
-  "rpcport":12454,
-  "pubtype":55,
-  "p2shtype":10,
-  "wiftype":198,
-  "txfee":10000,
-  "mm1": 1
-}
+  {
+    "coin": "RFOX",
+    "asset": "RFOX",
+    "fname": "RedFOX",
+    "rpcport": 32269,
+    "txversion": 4,
+    "overwintered": 1,
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
+  }
 
 # Example 3
-{
-  "coin": "ZEC",
-  "name": "zcash",
-  "fname": "Zcash",
-  "rpcport": 8232,
-  "taddr": 28,
-  "pubtype": 184,
-  "p2shtype": 189,
-  "wiftype": 128,
-  "txversion": 4,
-  "txfee": 10000,
-  "overwintered": 1,
-  "mm2": 1
-},
+  {
+    "coin": "ECA",
+    "name": "electra",
+    "fname": "Electra",
+    "rpcport": 5788,
+    "pubtype": 33,
+    "p2shtype": 40,
+    "wiftype": 161,
+    "txfee": 10000,
+    "txversion": 7,
+    "mm2":1,
+    "confpath": "USERHOME/.electra/Electra.conf",
+    "required_confirmations": 10
+  }
 
 # Example 4
-{
-  "coin": "REP",
-  "name": "augur",
-  "fname": "Augur",
-  "etomic": "0xE94327D07Fc17907b4DB788E5aDf2ed424adDff6",
-  "rpcport": 80,
-  "mm2": 1
-}
+  {
+    "coin": "BAT",
+    "name": "basic-attention-token",
+    "fname": "Basic Attention Token",
+    "etomic": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+    "rpcport": 80,
+    "mm2": 1,
+    "required_confirmations": 3
+  }
 ```
 
 #### General parameters
 
-`"mm2"` add this param if coin is confirmed working with MM2 (successful swap is made). 
+`"mm2"` add this param if coin is confirmed working with AtomicDEX (successful swap is made).
 
-`"required_confirmations"` the number of confirmations MM2 will wait for during the swap. Default value is 1.
+`"required_confirmations"` the number of confirmations AtomicDEX will wait for during the swap. Default value is 1. WARNING, this setting affects the security of the atomic swap. 51% attacks (double spending) are a threat and have been succesfully conducted in the past. Read more about it [here](https://komodoplatform.com/51-attack-how-komodo-can-help-prevent-one/). You can find a collection of coins and the theoretical cost of a 51% attack [here](https://www.crypto51.app/). Please be aware that some of the coins supported by AtomicDEX are vulnerable to such attacks, so consider using higher values for them, especially when dealing with high amounts.
+
+`"requires_notarization"` tells AtomicDEX to wait for a notarization during the swap. This only works with dPoW coins and `"required_confirmations"` must be set to `2` or higher.
+
 
 #### Bitcoin Protocol specific JSON
 
@@ -91,9 +96,9 @@ You need the following info in JSON format added to the [coins](coins) file:
 
 `"pubtype"`, `"p2shtype"`, and `"wiftype"` is the also very specific information about coin's parameters. This is specific to Bitcoin Protocol compatible coins only, and such information can be found in source code of the project. These parameters information can be expected in files like `src/init.cpp`, `src/base58.h`, and `src/chainparamsbase.h` if the project is following the **bitcoin** source code directory/files structure. If the parameters info is unclear then please have these confirmed by that coin/project's developers and make sure it's correct information.
 
-`"txfee"` is a value of default transactions fee, which must be specified in satoshies unit. BarterDEX uses this as the default transaction fee value when makes atomic swaps transactions.
+`"txfee"` is a value of default transactions fee, which must be specified in satoshies unit. AtomicDEX uses this as the default transaction fee value when making atomic swaps transactions. If set to `0`, AtomicDEX will use a dynamic fee based on output from `estimatesmartfee`.
 
-`"overwintered"` must be `1` if Overwinter upgrade was activated for the coin. Defaults to 1 for KMD and assetchains.
+`"overwintered"` must be `1` if Overwinter upgrade was activated for the coin.
 
 
 #### Ethereum Protocol specific JSON
@@ -120,8 +125,8 @@ Ethereum protocol specific coin/project add request are the most simplest. `"coi
 - It must have a valid JSON array with at least one Explorer URL in it. It's better if there are more than one explorer URLs in this JSON array. Example: `["http://example1.com/tx/","http://example2.com/tx/"]`.
 - The URL of Explorer must be pointing to the transactions URL. Check BTC file for an example: [explorers/BTC](explorers/BTC), which has `["https://www.blocktrail.com/BTC/tx/"]`. This explorers URL is used to show in graphical applications the link to the transactions like this [example link](https://www.blocktrail.com/BTC/tx/5268d045196e940ca8ba53b442c38a0f8c159002c912f8427239153dce984cc3/). Make sure this URL ends with `/`.
 
-### 4. Electrum Servers (Optional; Required for listing in Mobile GUIs) 
 
+### 4. Electrum Servers (Optional; Required for listing in Mobile GUIs)
 - Electrum file name must be coin's ticker name matching the `"coin"` value as specified in [coins](coins) file.
 - Electrum file name must not have any file extension. It is a file without any `.` extension.
 - Electrum file name must be all in **capital** letters.

--- a/coins
+++ b/coins
@@ -41,7 +41,8 @@
     "fname": "MoviToken",
     "etomic": "0x06F979E4F04ec565Ae8d7479a94C60dEF8846832",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "PEO",
@@ -716,7 +717,8 @@
     "fname": "Crypto.com",
     "etomic": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin":"CS",
@@ -815,7 +817,8 @@
     "fname": "Huobi Token",
     "etomic": "0x6f259637dcD74C767781E37Bc6133cd6A68aa161",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "HTS",
@@ -865,7 +868,8 @@
     "fname": "Chainlink",
     "etomic": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "LTR",
@@ -922,7 +926,8 @@
     "fname": "Pundi X",
     "etomic": "0xA15C7Ebe1f07CaF6bFF097D8a589fb8AC49Ae5B3",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "NS21",
@@ -1274,7 +1279,8 @@
     "fname": "Single Collateral DAI",
     "etomic": "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "DAI",
@@ -1282,7 +1288,8 @@
     "fname": "Multi-collateral DAI",
     "etomic": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "DDD",
@@ -1290,7 +1297,8 @@
     "fname": "Scry.info",
     "etomic": "0x9F5F3CFD7a32700C93F971637407ff17b91c7342",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "DGD",
@@ -1372,7 +1380,8 @@
     "fname": "Maker",
     "etomic": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "SNT",
@@ -1387,7 +1396,8 @@
     "fname": "Augur",
     "etomic": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "SRN",
@@ -1525,7 +1535,8 @@
     "fname": "Enjin Coin",
     "etomic": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "QSP",
@@ -1582,7 +1593,8 @@
     "fname": "Decentraland",
     "etomic": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "MCO",
@@ -1639,7 +1651,8 @@
     "fname": "Power Ledger",
     "etomic": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "PRL",

--- a/coins
+++ b/coins
@@ -635,7 +635,8 @@
     "fname": "ARPA Chain",
     "etomic": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "AWC",
@@ -643,7 +644,8 @@
     "fname": "Atomic Wallet Coin",
     "etomic": "0xaD22f63404f7305e4713CcBd4F296f34770513f4",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "BFT",
@@ -1180,7 +1182,8 @@
     "fname": "Paxos",
     "etomic": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "BUSD",
@@ -1188,7 +1191,8 @@
     "fname": "Binance USD",
     "etomic": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "TUSD",
@@ -1196,7 +1200,8 @@
     "fname": "TrueUSD",
     "etomic": "0x0000000000085d4780B73119b644AE5ecd22b376",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "USDC",
@@ -1204,7 +1209,8 @@
     "fname": "USD Coin",
     "etomic": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "USDT",
@@ -1350,7 +1356,8 @@
     "etomic": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
     "decimals": 18,
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "MDS",
@@ -1402,7 +1409,8 @@
     "fname": "0x",
     "etomic": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "BAT",
@@ -1410,7 +1418,8 @@
     "fname": "Basic Attention Token",
     "etomic": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "ETHOS",
@@ -1858,7 +1867,8 @@
     "fname": "Ethereum",
     "etomic": "0x0000000000000000000000000000000000000000",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "ZIL",
@@ -3252,7 +3262,8 @@
     "rpcport": 46705,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "PTX",
@@ -3262,8 +3273,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2,
-    "requires_notarization": true
+    "required_confirmations": 5
   },
   {
     "coin": "LUMBER",
@@ -3290,7 +3300,8 @@
     "fname": "Holo Token",
     "etomic": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "SOLVE",
@@ -3298,7 +3309,8 @@
     "fname": "Solve Token",
     "etomic": "0x446C9033E7516D820cc9a2ce2d0B7328b579406F",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "DENT",
@@ -3306,7 +3318,8 @@
     "fname": "Dent Coin",
     "etomic": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
     "rpcport": 80,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "COMMOD",

--- a/coins
+++ b/coins
@@ -8,7 +8,8 @@
     "p2shtype": 5,
     "wiftype": 128,
     "segwit": true,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 1
   },
   {
     "coin": "KMD",
@@ -21,7 +22,8 @@
     "txversion": 4,
     "overwintered": 1,
     "txfee": 1000,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 5
   },
   {
     "coin": "MCL",
@@ -31,7 +33,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "MOVI",
@@ -84,7 +86,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "K64",
@@ -94,7 +96,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "KMDICE",
@@ -104,7 +107,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "ILN",
@@ -117,7 +120,8 @@
     "p2p": 12985,
     "magic":"feb4cb23",
     "nSPV":"5.9.102.210, 5.9.253.195, 5.9.253.196, 5.9.253.197, 5.9.253.198, 5.9.253.199, 5.9.253.200, 5.9.253.201, 5.9.253.202, 5.9.253.203",
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "CHAIN",
@@ -127,7 +131,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "DP",
@@ -137,7 +141,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "GLXT",
@@ -147,7 +151,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "RFOX",
@@ -157,7 +161,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "THC",
@@ -167,7 +172,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "CCL",
@@ -177,7 +183,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "KOIN",
@@ -187,7 +194,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "COLX",
@@ -241,7 +249,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "AYWA",
@@ -353,7 +361,8 @@
     "txfee": 10000,
     "txversion": 7,
     "mm2":1,
-    "confpath": "USERHOME/.electra/Electra.conf"
+    "confpath": "USERHOME/.electra/Electra.conf",
+    "required_confirmations": 10
   },
   {
     "coin":"POLIS",
@@ -440,7 +449,8 @@
     "wiftype": 204,
     "txfee": 10000,
     "confpath": "USERHOME/.axecore/axe.conf",
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 10
   },
   {
     "coin": "BCBC",
@@ -1112,7 +1122,8 @@
     "wiftype": 142,
     "txfee": 1000000,
     "segwit": true,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 10
   },
   {
     "coin": "PXT",
@@ -1959,7 +1970,8 @@
     "p2shtype": 122,
     "wiftype": 128,
     "txfee": 1000000,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 4
   },
   {
     "coin": "VIVO",
@@ -2032,7 +2044,8 @@
     "fname": "Utrum",
     "rpcport": 12467,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "HTML",
@@ -2206,7 +2219,8 @@
     "rpcport": 8800,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "ETOMIC",
@@ -2224,7 +2238,8 @@
     "rpcport": 12927,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "INN",
@@ -2332,7 +2347,8 @@
     "wiftype": 128,
     "txfee": 1000,
     "segwit": true,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 1
   },
   {
     "coin": "QMC",
@@ -2353,7 +2369,8 @@
     "p2shtype": 50,
     "wiftype": 128,
     "segwit": true,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 4
   },
   {
     "coin": "PGN",
@@ -2393,7 +2410,7 @@
     "rpcport": 14337,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "BTCZ",
@@ -2456,7 +2473,9 @@
     "wiftype": 188,
     "txfee": 10000,
     "segwit": true,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "888",
@@ -2690,7 +2709,8 @@
     "p2shtype": 85,
     "wiftype": 150,
     "txfee": 10000,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 10
   },
   {
     "coin": "NIX",
@@ -2712,7 +2732,9 @@
     "p2shtype": 5,
     "wiftype": 176,
     "txfee": 100000,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "SYS",
@@ -2745,7 +2767,8 @@
     "p2shtype": 16,
     "wiftype": 204,
     "txfee": 10000,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 2
   },
   {
     "coin": "STRAT",
@@ -2859,7 +2882,9 @@
     "rpcport": 10196,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "VRSC",
@@ -2869,7 +2894,7 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "ZILLA",
@@ -2877,7 +2902,8 @@
     "fname": "ChainZilla",
     "rpcport": 10041,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "JUMBLR",
@@ -2886,7 +2912,9 @@
     "rpcport": 15106,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "DOGE",
@@ -2897,7 +2925,8 @@
     "p2shtype": 22,
     "wiftype": 158,
     "txfee": 500000000,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 2
   },
   {
     "coin": "HUSH",
@@ -2907,7 +2936,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "ZEC",
@@ -2923,7 +2953,8 @@
     "version_group_id": "0x892f2085",
     "consensus_branch_id": "0x2BB40E60",
     "txfee": 10000,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 3
   },
   {
     "coin": "DGB",
@@ -2935,7 +2966,8 @@
     "wiftype": 128,
     "txfee": 100000,
     "segwit": true,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 7
   },
   {
     "coin": "ZET",
@@ -2956,7 +2988,9 @@
     "p2shtype": 5,
     "wiftype": 166,
     "txfee": 1000000,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "LTC",
@@ -2968,7 +3002,8 @@
     "wiftype": 176,
     "txfee": 10000,
     "segwit": true,
-    "mm2": 1
+    "mm2": 1,
+    "required_confirmations": 2
   },
   {
     "coin": "SUPERNET",
@@ -2978,7 +3013,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "WLC",
@@ -2988,7 +3024,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "PANGEA",
@@ -2997,7 +3034,9 @@
     "rpcport": 14068,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "DEX",
@@ -3007,7 +3046,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "DSEC",
@@ -3016,7 +3056,7 @@
     "rpcport": 11557,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "BET",
@@ -3025,7 +3065,9 @@
     "rpcport": 14250,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "CRYPTO",
@@ -3034,7 +3076,9 @@
     "rpcport": 8516,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "HODL",
@@ -3043,7 +3087,9 @@
     "rpcport": 14431,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "MSHARK",
@@ -3052,7 +3098,9 @@
     "rpcport": 8846,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "BOTS",
@@ -3061,7 +3109,9 @@
     "rpcport": 11964,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "MGW",
@@ -3070,7 +3120,9 @@
     "rpcport": 12386,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "COQUI",
@@ -3080,7 +3132,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "KV",
@@ -3089,7 +3142,9 @@
     "rpcport": 8299,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "CEAL",
@@ -3098,7 +3153,7 @@
     "rpcport": 11116,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "MESH",
@@ -3107,7 +3162,9 @@
     "rpcport": 9455,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "ROGER",
@@ -3146,7 +3203,7 @@
     "rpcport": 20731,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "DION",
@@ -3155,7 +3212,7 @@
     "rpcport": 23895,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "OURC",
@@ -3165,7 +3222,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "ZEXO",
@@ -3175,7 +3233,8 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin":"ABP", 
@@ -3202,7 +3261,9 @@
     "rpcport": 61939,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "mm2": 1,
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "LUMBER",
@@ -3211,7 +3272,7 @@
     "rpcport": 26301,
     "txversion": 4,
     "overwintered": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   },
   {
     "coin": "GCH",
@@ -3255,6 +3316,6 @@
     "txversion": 4,
     "overwintered": 1,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 5
   }
 ]

--- a/coins
+++ b/coins
@@ -23,7 +23,7 @@
     "overwintered": 1,
     "txfee": 1000,
     "mm2": 1,
-    "required_confirmations": 5
+    "required_confirmations": 4
   },
   {
     "coin": "MCL",
@@ -361,9 +361,9 @@
     "wiftype": 161,
     "txfee": 10000,
     "txversion": 7,
-    "mm2":1,
+    "mm2": 1,
     "confpath": "USERHOME/.electra/Electra.conf",
-    "required_confirmations": 10
+    "required_confirmations": 5
   },
   {
     "coin":"POLIS",
@@ -451,7 +451,7 @@
     "txfee": 10000,
     "confpath": "USERHOME/.axecore/axe.conf",
     "mm2": 1,
-    "required_confirmations": 10
+    "required_confirmations": 5
   },
   {
     "coin": "BCBC",
@@ -1130,7 +1130,7 @@
     "txfee": 1000000,
     "segwit": true,
     "mm2": 1,
-    "required_confirmations": 10
+    "required_confirmations": 5
   },
   {
     "coin": "PXT",
@@ -1994,7 +1994,7 @@
     "wiftype": 128,
     "txfee": 1000000,
     "mm2": 1,
-    "required_confirmations": 4
+    "required_confirmations": 3
   },
   {
     "coin": "VIVO",
@@ -2393,7 +2393,7 @@
     "wiftype": 128,
     "segwit": true,
     "mm2": 1,
-    "required_confirmations": 4
+    "required_confirmations": 3
   },
   {
     "coin": "PGN",

--- a/coins
+++ b/coins
@@ -2242,6 +2242,7 @@
     "rpcport": 8800,
     "txversion": 4,
     "overwintered": 1,
+    "mm2": 1,
     "required_confirmations": 2,
     "requires_notarization": true
   },
@@ -2261,6 +2262,7 @@
     "rpcport": 12927,
     "txversion": 4,
     "overwintered": 1,
+    "mm2": 1,
     "required_confirmations": 2,
     "requires_notarization": true
   },
@@ -3275,6 +3277,7 @@
     "rpcport": 46705,
     "txversion": 4,
     "overwintered": 1,
+    "mm2": 1,
     "required_confirmations": 2,
     "requires_notarization": true
   },

--- a/coins
+++ b/coins
@@ -23,7 +23,8 @@
     "overwintered": 1,
     "txfee": 1000,
     "mm2": 1,
-    "required_confirmations": 4
+    "required_confirmations": 2,
+    "requires_notarization": true
   },
   {
     "coin": "MCL",


### PR DESCRIPTION
- made changes to reflect https://github.com/KomodoPlatform/atomicDEX-API/commit/0f11b2dd84307c9254a36fccf32db84ad1c7eac1
- ACs that are notarized require notarization
- all other ACs require 5 confirmations
- ERC20 require 3 confirmations
- set confirmations higher for the UTXO coins supported in the GUI